### PR TITLE
Bump optparse-applicative, haskell-src-exts bounds

### DIFF
--- a/packunused.cabal
+++ b/packunused.cabal
@@ -70,7 +70,7 @@ executable packunused
   build-depends:
     base                 >=4.5  && <4.8,
     Cabal                >=1.14 && <1.21,
-    optparse-applicative >= 0.8 && <0.11,
+    optparse-applicative >= 0.8 && <0.12,
     directory            >=1.1  && <1.3,
     filepath             ==1.3.*,
     haskell-src-exts     >=1.13 && <1.17,


### PR DESCRIPTION
Allow `packunused` to build with the latest versions of `optparse-applicative` (0.10) and `haskell-src-exts` (0.16), neither of which changed significantly enough to affect the behavior of `packunused`.
