### PR TITLE
Loosen (upper) version bounds for optparse-applicative and haskell-src-exts

### DIFF
--- a/packunused.cabal
+++ b/packunused.cabal
@@ -70,8 +70,8 @@ executable packunused
   build-depends:
     base                 >=4.5  && <4.8,
     Cabal                >=1.14 && <1.21,
-    optparse-applicative == 0.8.*,
+    optparse-applicative < 0.12,
     directory            >=1.1  && <1.3,
     filepath             ==1.3.*,
-    haskell-src-exts     >=1.13 && <1.16,
+    haskell-src-exts     >=1.13 && <1.17,
     split                ==0.2.*


### PR DESCRIPTION
I've built and tested packunused with optparse-applicative-0.11.0.1 and haskell-src-exts-1.16.0. It seems to work!
