### PR TITLE
Bump filepath upper version bounds

### DIFF
--- a/packunused.cabal
+++ b/packunused.cabal
@@ -72,6 +72,6 @@ executable packunused
     Cabal                >=1.14 && <1.23,
     optparse-applicative >=0.8  && <0.12,
     directory            >=1.1  && <1.3,
-    filepath             ==1.3.*,
+    filepath             >=1.3  && <1.5,
     haskell-src-exts     >=1.13 && <1.17,
     split                ==0.2.*


### PR DESCRIPTION
Allow `packunused` to build with `filepath-1.4.0.0` (and GHC 7.10, moreover).