### PR TITLE
add support for projects compiled with stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 dist/
+.stack-work

--- a/packunused.cabal
+++ b/packunused.cabal
@@ -71,6 +71,7 @@ source-repository head
 
 executable packunused
   main-is:             packunused.hs
+  other-modules:       Paths_packunused
   default-language:    Haskell2010
   other-extensions:    CPP, RecordWildCards
   ghc-options:         -Wall -fwarn-tabs -fno-warn-unused-do-bind

--- a/packunused.cabal
+++ b/packunused.cabal
@@ -31,6 +31,13 @@ description:
   > cabal build --ghc-option=-ddump-minimal-imports
   > packunused
   .
+  Alternatively:
+  .
+  > # stack setup --upgrade-cabal'  # necessary only when stack's global "Cabal" installation is out of date
+  > stack clean
+  > stack build --ghc-options '-ddump-minimal-imports -O0'
+  > packunused
+  .
   The @-O0 --disable-library-profiling@ options are just to speed up
   compilation. In some cases you might want to pass additional options
   to the @configure@ step, such as @--enable-benchmark@ or
@@ -70,8 +77,9 @@ executable packunused
   build-depends:
     base                 >=4.5  && <4.9,
     Cabal                >=1.14 && <1.23,
-    optparse-applicative >=0.8  && <0.12,
+    optparse-applicative >=0.8,
     directory            >=1.1  && <1.3,
     filepath             >=1.3  && <1.5,
-    haskell-src-exts     >=1.13 && <1.17,
-    split                ==0.2.*
+    haskell-src-exts     >=1.13,
+    split                ==0.2.*,
+    process

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,32 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-5.0
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
Well, I just wrote this and then found out [somebody else wrote the same thing 5 days ago](https://github.com/hvr/packunused/pull/20)!  Wish I'd checked for pull requests first.

Nevertheless, I'm submitting the PR because mine has some advantages:

* does not add dependency on Text
* documents `stack setup --upgrade-cabal`
* tests for existence of `stack.yaml` instead of `.stack-work` (I think that's more proper)
* adds `stack.yaml`
* updates cabal bounds (well, eliminates upper bounds that were too restrictive)