### PR TITLE
Updated bounds for optparse-applcative and haskell-src-exts

### DIFF
--- a/packunused.cabal
+++ b/packunused.cabal
@@ -70,8 +70,8 @@ executable packunused
   build-depends:
     base                 >=4.5  && <4.9,
     Cabal                >=1.14 && <1.23,
-    optparse-applicative >=0.8  && <0.12,
+    optparse-applicative >=0.8  && <0.13,
     directory            >=1.1  && <1.3,
     filepath             >=1.3  && <1.5,
-    haskell-src-exts     >=1.13 && <1.17,
+    haskell-src-exts     >=1.13 && <1.18,
     split                ==0.2.*


### PR DESCRIPTION
Just built with this locally, and it works like a charm.