### PR TITLE
Update for Cabal 1.24 and GHC 8.0.1

### DIFF
--- a/packunused.cabal
+++ b/packunused.cabal
@@ -77,11 +77,11 @@ executable packunused
   other-extensions:    CPP, RecordWildCards
   ghc-options:         -Wall -fwarn-tabs -fno-warn-unused-do-bind
   build-depends:
-    base                 >=4.5  && <4.9,
-    Cabal                >=1.14 && <1.23,
+    base                 >=4.5  && <4.10,
+    Cabal                >=1.24 && <1.25,
     optparse-applicative >=0.8  && <0.13,
     directory            >=1.1  && <1.3,
     filepath             >=1.3  && <1.5,
-    haskell-src-exts     >=1.13 && <1.18,
+    haskell-src-exts     >=1.14 && <1.18,
     process              >=1.1  && <1.5,
     split                ==0.2.*


### PR DESCRIPTION
Drops support for Cabal <1.24 and haskell-src-exts <1.14.