### PR TITLE
Add GHC 8.2.1/8.2.2 to Travis CI. Allow to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,15 @@ matrix:
     - env: CABALVER=head GHCVER=8.0.2
       compiler: ": #GHC 8.0.2"
       addons: {apt: {packages: [cabal-install-head,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=8.2.1
+      compiler: ": #GHC 8.2.1"
+      addons: {apt: {packages: [cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=8.2.2
+      compiler: ": #GHC 8.2.2"
+      addons: {apt: {packages: [cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+  allow_failures:
+    - env: CABALVER=head GHCVER=8.2.1
+    - env: CABALVER=head GHCVER=8.2.2
 
 before_install:
  - unset CC

--- a/packunused.cabal
+++ b/packunused.cabal
@@ -11,7 +11,7 @@ copyright:           © 2014 Herbert Valerio Riedel
 category:            Distribution
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:         GHC==8.2.2, GHC==8.2.1, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
 description:
   This simple CLI tool allows to find out which of the packages listed as
   @build-depends@ in a Cabal package description file are redundant.


### PR DESCRIPTION
A first step towards https://github.com/hvr/packunused/issues/32.

I was having some trouble getting multi-ghc-travis to work so I added this stuff manually.