### PR TITLE
Bump dependency for base to next major version

### DIFF
--- a/packunused.cabal
+++ b/packunused.cabal
@@ -76,8 +76,8 @@ executable packunused
   default-language:    Haskell2010
   other-extensions:    CPP, RecordWildCards
   ghc-options:         -Wall -fwarn-tabs -fno-warn-unused-do-bind
-  build-depends: base                 >= 4.5    && < 4.11
-               , Cabal                >= 2.0    && < 2.1
+  build-depends: base                 >= 4.5    && < 5
+               , Cabal                >= 2.0    && < 2.3
                , optparse-applicative >= 0.8    && < 0.15
                , directory            >= 1.1    && < 1.4
                , filepath             >= 1.3    && < 1.5


### PR DESCRIPTION
So we don't have to constantly be updating it. They are pretty good with keeping backwards-compatibility.

Tested with base 4.11 and cabal 2.2.